### PR TITLE
feat: add offline track caching controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -54,6 +54,8 @@
         <div class="track-info">01. Lead with Your Hips</div>
         <a class="download-link" href="music/Lead_with_Your_Hips.m4a" download>Download M4A</a>
         <a class="download-link" href="music/Lead_with_Your_Hips.wav" download>Download WAV</a>
+        <button class="save-offline" data-url="/music/Lead_with_Your_Hips.m4a">Save for offline</button>
+        <button class="remove-offline" data-url="/music/Lead_with_Your_Hips.m4a">Remove from offline</button>
     </div>
 <div class="track">
     <audio controls preload="metadata">
@@ -64,6 +66,8 @@
     <div class="track-info">02. Midnight Attitude</div>
     <a class="download-link" href="music/Midnight_Attitude.m4a" download>Download M4A</a>
     <a class="download-link" href="music/Midnight_Attitude.wav" download>Download WAV</a>
+    <button class="save-offline" data-url="/music/Midnight_Attitude.m4a">Save for offline</button>
+    <button class="remove-offline" data-url="/music/Midnight_Attitude.m4a">Remove from offline</button>
 </div>
 
 <div class="track">
@@ -75,6 +79,8 @@
     <div class="track-info">03. Full Capacity</div>
     <a class="download-link" href="music/Full_Capacity.m4a" download>Download M4A</a>
     <a class="download-link" href="music/Full_Capacity.wav" download>Download WAV</a>
+    <button class="save-offline" data-url="/music/Full_Capacity.m4a">Save for offline</button>
+    <button class="remove-offline" data-url="/music/Full_Capacity.m4a">Remove from offline</button>
 </div>
 
 <div class="track">
@@ -86,6 +92,8 @@
     <div class="track-info">04. Deep Sleep</div>
     <a class="download-link" href="music/Deep_Sleep.m4a" download>Download M4A</a>
     <a class="download-link" href="music/Deep_Sleep.wav" download>Download WAV</a>
+    <button class="save-offline" data-url="/music/Deep_Sleep.m4a">Save for offline</button>
+    <button class="remove-offline" data-url="/music/Deep_Sleep.m4a">Remove from offline</button>
 </div>
 
 <div class="track">
@@ -97,6 +105,8 @@
     <div class="track-info">05. Level 9</div>
     <a class="download-link" href="music/Level_9.m4a" download>Download M4A</a>
     <a class="download-link" href="music/Level_9.wav" download>Download WAV</a>
+    <button class="save-offline" data-url="/music/Level_9.m4a">Save for offline</button>
+    <button class="remove-offline" data-url="/music/Level_9.m4a">Remove from offline</button>
 </div>
 
 <div class="track">
@@ -108,6 +118,8 @@
     <div class="track-info">06. windy</div>
     <a class="download-link" href="music/windy.m4a" download>Download M4A</a>
     <a class="download-link" href="music/windy.wav" download>Download WAV</a>
+    <button class="save-offline" data-url="/music/windy.m4a">Save for offline</button>
+    <button class="remove-offline" data-url="/music/windy.m4a">Remove from offline</button>
 </div>
 
 <div class="track">
@@ -119,6 +131,8 @@
     <div class="track-info">07. T-Rex T-Rex</div>
     <a class="download-link" href="music/T-Rex_T-Rex.m4a" download>Download M4A</a>
     <a class="download-link" href="music/T-Rex_T-Rex.wav" download>Download WAV</a>
+    <button class="save-offline" data-url="/music/T-Rex_T-Rex.m4a">Save for offline</button>
+    <button class="remove-offline" data-url="/music/T-Rex_T-Rex.m4a">Remove from offline</button>
 </div>
 
 <div class="track">
@@ -130,6 +144,8 @@
     <div class="track-info">08. Walking on the C</div>
     <a class="download-link" href="music/Walking_on_the_C.m4a" download>Download M4A</a>
     <a class="download-link" href="music/Walking_on_the_C.wav" download>Download WAV</a>
+    <button class="save-offline" data-url="/music/Walking_on_the_C.m4a">Save for offline</button>
+    <button class="remove-offline" data-url="/music/Walking_on_the_C.m4a">Remove from offline</button>
 </div>
 
 <div class="track">
@@ -141,6 +157,8 @@
     <div class="track-info">09. Won 2 1</div>
     <a class="download-link" href="music/Won_2_1.m4a" download>Download M4A</a>
     <a class="download-link" href="music/Won_2_1.wav" download>Download WAV</a>
+    <button class="save-offline" data-url="/music/Won_2_1.m4a">Save for offline</button>
+    <button class="remove-offline" data-url="/music/Won_2_1.m4a">Remove from offline</button>
 </div>
 
     <!-- Fallback message for users with JavaScript disabled -->
@@ -183,7 +201,55 @@
     const autoplayToggle = document.getElementById('autoplay-toggle');
     const tracks = document.querySelectorAll('.track audio');
     const trackContainers = document.querySelectorAll('.track');
+    const saveButtons = document.querySelectorAll('.save-offline');
+    const removeButtons = document.querySelectorAll('.remove-offline');
     let currentIndex = 0;
+
+    function sendToServiceWorker(action, url) {
+        navigator.serviceWorker.ready.then((registration) => {
+            if (registration.active) {
+                registration.active.postMessage({ action, url });
+                console.log(`Sent ${action} request for ${url}`);
+            }
+        });
+    }
+
+    saveButtons.forEach((button) => {
+        button.addEventListener('click', () => {
+            sendToServiceWorker('save', button.dataset.url);
+        });
+    });
+
+    removeButtons.forEach((button) => {
+        button.disabled = true;
+        button.classList.add('disabled');
+        button.addEventListener('click', () => {
+            sendToServiceWorker('remove', button.dataset.url);
+        });
+    });
+
+    navigator.serviceWorker.addEventListener('message', (event) => {
+        const { status, url } = event.data || {};
+        if (!status || !url) return;
+
+        const saveBtn = document.querySelector(`button.save-offline[data-url="${url}"]`);
+        const removeBtn = document.querySelector(`button.remove-offline[data-url="${url}"]`);
+        if (!saveBtn || !removeBtn) return;
+
+        if (status === 'saved') {
+            saveBtn.textContent = 'Saved';
+            saveBtn.disabled = true;
+            saveBtn.classList.add('disabled');
+            removeBtn.disabled = false;
+            removeBtn.classList.remove('disabled');
+        } else if (status === 'removed') {
+            saveBtn.textContent = 'Save for offline';
+            saveBtn.disabled = false;
+            saveBtn.classList.remove('disabled');
+            removeBtn.disabled = true;
+            removeBtn.classList.add('disabled');
+        }
+    });
 
     // Autoplay toggle functionality
     autoplayToggle.addEventListener('click', () => {
@@ -256,7 +322,7 @@
     });
     </script>
     <footer style="margin-top: 20px; color: #888; font-size: 0.8em;">
-        Version 1.0.3
+        Version 1.0.5
     </footer>
 </html>
 

--- a/sw.js
+++ b/sw.js
@@ -1,45 +1,26 @@
 // sw.js - Service Worker for caching the album player resources
 
-const CACHE_NAME = 'base3-album-cache-v3';
+const CACHE_NAME = 'base3-album-cache-v5';
 const urlsToCache = [
     '/',
-    'index.html',
-    '/images/Base3Logo.jpg',
-    '/music/Lead_with_Your_Hips.m4a',
-    '/music/Midnight_Attitude.m4a',
-    '/music/Full_Capacity.m4a',
-    '/music/Deep_Sleep.m4a',
-    '/music/Level_9.m4a',
-    '/music/windy.m4a',
-    '/music/T-Rex_T-Rex.m4a',
-    '/music/Walking_on_the_C.m4a',
-    '/music/Won_2_1.m4a',
-    '/music/Lead_with_Your_Hips.wav',
-    '/music/Midnight_Attitude.wav',
-    '/music/Full_Capacity.wav',
-    '/music/Deep_Sleep.wav',
-    '/music/Level_9.wav',
-    '/music/windy.wav',
-    '/music/T-Rex_T-Rex.wav',
-    '/music/Walking_on_the_C.wav',
-    '/music/Won_2_1.wav',
-    // Add other assets and audio files here as needed
+    '/index.html',
+    '/images/Base3Logo.jpg'
 ];
 
 self.addEventListener('install', (event) => {
-    // Perform install steps
+    self.skipWaiting();
     event.waitUntil(
-        caches.open(CACHE_NAME)
-            .then((cache) => {
-                console.log('Opened cache');
-                return Promise.all(
-                    urlsToCache.map(url => 
-                        cache.add(url)
-                            .then(() => console.log(`Successfully cached ${url}`))
-                            .catch(error => console.error(`Failed to cache ${url}:`, error))
-                    )
-                );
-            })
+        caches.open(CACHE_NAME).then((cache) => {
+            console.log('Opened cache');
+            return Promise.all(
+                urlsToCache.map((url) =>
+                    cache
+                        .add(url)
+                        .then(() => console.log(`Successfully cached ${url}`))
+                        .catch((error) => console.error(`Failed to cache ${url}:`, error))
+                )
+            );
+        })
     );
 });
 
@@ -48,32 +29,17 @@ self.addEventListener('fetch', (event) => {
 
     if (requestURL.pathname.startsWith('/music/')) {
         event.respondWith(
-            caches.open(CACHE_NAME).then((cache) => {
-                return cache.match(event.request).then((cachedResponse) => {
-                    if (cachedResponse) {
-                        console.log(`Serving ${event.request.url} from cache`);
-                        return cachedResponse;
-                    }
-                    console.log(`Fetching ${event.request.url} from network`);
-
-                    // Clone the request and remove Range headers
-                    const modifiedRequest = new Request(event.request, {
-                        headers: new Headers(event.request.headers)
-                    });
-                    modifiedRequest.headers.delete('Range');
-
-                    return fetch(modifiedRequest).then((networkResponse) => {
-                        if (!networkResponse || networkResponse.status !== 200) {
-                            throw new Error('Failed to fetch or non-200 response');
-                        }
-                        cache.put(event.request, networkResponse.clone());
-                        return networkResponse;
-                    }).catch((error) => {
-                        console.error(`Fetch failed for ${event.request.url}:`, error);
-                        return new Response('Offline - song not available in cache', {
-                            status: 408,
-                            statusText: 'Network and cache failed',
-                        });
+            caches.match(event.request).then((cachedResponse) => {
+                if (cachedResponse) {
+                    console.log(`Serving ${event.request.url} from cache`);
+                    return cachedResponse;
+                }
+                console.log(`Fetching ${event.request.url} from network`);
+                return fetch(event.request).catch((error) => {
+                    console.error(`Fetch failed for ${event.request.url}:`, error);
+                    return new Response('Offline - song not available in cache', {
+                        status: 408,
+                        statusText: 'Network and cache failed',
                     });
                 });
             })
@@ -91,15 +57,60 @@ self.addEventListener('fetch', (event) => {
 self.addEventListener('activate', (event) => {
     const cacheWhitelist = [CACHE_NAME];
     event.waitUntil(
-        caches.keys().then((cacheNames) => {
-            return Promise.all(
-                cacheNames.map((cacheName) => {
-                    if (!cacheWhitelist.includes(cacheName)) {
-                        return caches.delete(cacheName);
-                    }
-                })
-            );
-        })
+        caches
+            .keys()
+            .then((cacheNames) => {
+                return Promise.all(
+                    cacheNames.map((cacheName) => {
+                        if (!cacheWhitelist.includes(cacheName)) {
+                            return caches.delete(cacheName);
+                        }
+                    })
+                );
+            })
+            .then(() => self.clients.claim())
     );
+});
+
+self.addEventListener('message', (event) => {
+    const { action, url } = event.data || {};
+    if (!url) return;
+
+    const respond = (status) => {
+        if (event.source) {
+            event.source.postMessage({ status, url });
+        }
+    };
+
+    if (action === 'save') {
+        event.waitUntil(
+            caches.open(CACHE_NAME).then((cache) => {
+                return fetch(url)
+                    .then((response) => {
+                        if (!response.ok) {
+                            throw new Error(`Network response was not ok for ${url}`);
+                        }
+                        return cache.put(url, response.clone());
+                    })
+                    .then(() => {
+                        console.log(`Cached ${url}`);
+                        respond('saved');
+                    })
+                    .catch((error) => {
+                        console.error(`Failed to cache ${url}:`, error);
+                        respond('error');
+                    });
+            })
+        );
+    } else if (action === 'remove') {
+        event.waitUntil(
+            caches.open(CACHE_NAME).then((cache) => {
+                return cache.delete(url).then((deleted) => {
+                    console.log(deleted ? `Removed ${url} from cache` : `${url} not found in cache`);
+                    respond('removed');
+                });
+            })
+        );
+    }
 });
 


### PR DESCRIPTION
## Summary
- add Save for offline and Remove from offline buttons for each track
- send postMessages to the service worker to cache or remove individual tracks
- service worker caches only requested tracks and serves them from cache when available
- service worker now confirms save/remove actions and activates new versions immediately

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b26a86a2a48320bca53e0274a7dfe3