### PR TITLE
Handle audio range requests in service worker

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -28,6 +28,14 @@ self.addEventListener('fetch', (event) => {
     const requestURL = new URL(event.request.url);
 
     if (requestURL.pathname.startsWith('/music/')) {
+        // Audio requests sometimes include a Range header for streaming.
+        // These are best handled directly by the network to avoid issues
+        // with partial content and cache lookups.
+        if (event.request.headers.has('range')) {
+            event.respondWith(fetch(event.request));
+            return;
+        }
+
         event.respondWith(
             caches.match(event.request).then((cachedResponse) => {
                 if (cachedResponse) {


### PR DESCRIPTION
## Summary
- Avoid caching range-based audio requests by passing them directly to the network

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/base3/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68b29991a8748320915ddf0e0e45edca