### PR TITLE
Add minimal PWA manifest and theme color

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ A static web application for listening to the album **Base 3** online.
 
 ## Usage
 Open `index.html` in a modern browser to play tracks. A service worker caches audio
-files for offline playback.
+files for offline playback. The app also includes a web app manifest and theme color
+so it can be installed like a Progressive Web App.
 
 ## License
 This project is made available under **your choice** of the following licenses:

--- a/index.html
+++ b/index.html
@@ -6,6 +6,8 @@
   <meta property="og:title" content="Base 3 - Album Player" />
   <meta property="og:description" content="Listen to the tracks from Gavin's album 'Base 3' online." />
   <meta property="og:image" content="images/Base3Logo.jpg" />
+  <link rel="manifest" href="manifest.json" />
+  <meta name="theme-color" content="#1db954" />
   <title>Base 3 - Album Player</title>
   <style>
     body { font-family: Arial, sans-serif; margin: 0; padding: 0; display: flex; flex-direction: column; align-items: center; background-color: #222; color: #fff; }

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,20 @@
+{
+  "name": "Base 3 Album Player",
+  "short_name": "Base3",
+  "start_url": ".",
+  "display": "standalone",
+  "background_color": "#222222",
+  "theme_color": "#1db954",
+  "icons": [
+    {
+      "src": "images/Base3Logo.jpg",
+      "sizes": "192x192",
+      "type": "image/jpeg"
+    },
+    {
+      "src": "images/Base3Logo.jpg",
+      "sizes": "512x512",
+      "type": "image/jpeg"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Add `manifest.json` with icons and colors
- Link manifest and theme color in `index.html`
- Document PWA install support in README

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b299f59600832093cec94bd8928778