### PR TITLE
feat: store audio tracks in indexeddb

### DIFF
--- a/index.html
+++ b/index.html
@@ -206,12 +206,20 @@
       const removeButtons = document.querySelectorAll('.remove-offline');
       let currentIndex = 0;
 
+      const swReady = 'serviceWorker' in navigator
+        ? new Promise(resolve => {
+            if (navigator.serviceWorker.controller) {
+              resolve();
+            } else {
+              navigator.serviceWorker.addEventListener('controllerchange', () => resolve(), { once: true });
+            }
+          })
+        : Promise.resolve();
+
       function sendToServiceWorker(action, url) {
         if (!('serviceWorker' in navigator)) return;
-        navigator.serviceWorker.ready.then(registration => {
-          if (registration.active) {
-            registration.active.postMessage({ action, url });
-          }
+        swReady.then(() => {
+          navigator.serviceWorker.controller?.postMessage({ action, url });
         });
       }
 
@@ -234,13 +242,26 @@
         sendToServiceWorker('check', button.dataset.url);
       });
 
+      let _lastProgressAt = 0;
       if ('serviceWorker' in navigator) {
         navigator.serviceWorker.addEventListener('message', (event) => {
-          const { status, url } = event.data || {};
+          const { status, url, received, size } = event.data || {};
           if (!status || !url) return;
           const saveBtn = document.querySelector(`button.save-offline[data-url="${url}"]`);
           const removeBtn = document.querySelector(`button.remove-offline[data-url="${url}"]`);
           if (!saveBtn || !removeBtn) return;
+
+          if (status === 'downloading') {
+            const now = performance.now();
+            if (now - _lastProgressAt < 150) return;
+            _lastProgressAt = now;
+
+            const pct = size ? Math.round((received / size) * 100) : 0;
+            saveBtn.textContent = `Saving ${pct}%`;
+            saveBtn.disabled = true;
+            saveBtn.classList.add('disabled');
+            return;
+          }
 
           if (status === 'saved') {
             saveBtn.textContent = 'Saved';
@@ -254,6 +275,10 @@
             saveBtn.classList.remove('disabled');
             removeBtn.disabled = true;
             removeBtn.classList.add('disabled');
+          } else if (status === 'error') {
+            saveBtn.textContent = 'Error';
+            saveBtn.disabled = false;
+            saveBtn.classList.remove('disabled');
           }
         });
       }

--- a/sw.js
+++ b/sw.js
@@ -1,132 +1,235 @@
-// sw.js - Service Worker for caching the album player resources
+// sw.js - Service Worker using IndexedDB for audio storage
 
-const CACHE_NAME = 'base3-album-cache-v6';
-const urlsToCache = [
-    '/',
-    '/index.html',
-    '/images/Base3Logo.jpg'
+const CACHE_NAME = 'base3-shell-v1';
+const SHELL_ASSETS = [
+  '/',
+  '/index.html',
+  '/images/Base3Logo.jpg'
 ];
 
-self.addEventListener('install', (event) => {
-    self.skipWaiting();
-    event.waitUntil(
-        caches.open(CACHE_NAME).then((cache) => {
-            console.log('Opened cache');
-            return Promise.all(
-                urlsToCache.map((url) =>
-                    cache
-                        .add(url)
-                        .then(() => console.log(`Successfully cached ${url}`))
-                        .catch((error) => console.error(`Failed to cache ${url}:`, error))
-                )
-            );
-        })
-    );
-});
+// IndexedDB setup ----------------------------------------------------------
+const DB_NAME = 'base3';
+const DB_VERSION = 1;
 
-self.addEventListener('fetch', (event) => {
-    const requestURL = new URL(event.request.url);
+function openDB() {
+  return new Promise((resolve, reject) => {
+    const req = indexedDB.open(DB_NAME, DB_VERSION);
 
-    if (requestURL.pathname.startsWith('/music/')) {
-        // Audio requests sometimes include a Range header for streaming.
-        // These are best handled directly by the network to avoid issues
-        // with partial content and cache lookups.
-        if (event.request.headers.has('range')) {
-            event.respondWith(fetch(event.request));
-            return;
-        }
-
-        event.respondWith(
-            caches.match(event.request).then((cachedResponse) => {
-                if (cachedResponse) {
-                    console.log(`Serving ${event.request.url} from cache`);
-                    return cachedResponse;
-                }
-                console.log(`Fetching ${event.request.url} from network`);
-                return fetch(event.request).catch((error) => {
-                    console.error(`Fetch failed for ${event.request.url}:`, error);
-                    return new Response('Offline - song not available in cache', {
-                        status: 408,
-                        statusText: 'Network and cache failed',
-                    });
-                });
-            })
-        );
-    } else {
-        // Handle non-audio requests
-        event.respondWith(
-            caches.match(event.request).then((response) => {
-                return response || fetch(event.request);
-            })
-        );
-    }
-});
-
-self.addEventListener('activate', (event) => {
-    const cacheWhitelist = [CACHE_NAME];
-    event.waitUntil(
-        caches
-            .keys()
-            .then((cacheNames) => {
-                return Promise.all(
-                    cacheNames.map((cacheName) => {
-                        if (!cacheWhitelist.includes(cacheName)) {
-                            return caches.delete(cacheName);
-                        }
-                    })
-                );
-            })
-            .then(() => self.clients.claim())
-    );
-});
-
-self.addEventListener('message', (event) => {
-    const { action, url } = event.data || {};
-    if (!url) return;
-
-    const respond = (status) => {
-        if (event.source) {
-            event.source.postMessage({ status, url });
-        }
+    req.onupgradeneeded = () => {
+      const db = req.result;
+      if (!db.objectStoreNames.contains('tracks')) {
+        db.createObjectStore('tracks', { keyPath: 'trackKey' });
+      }
+      if (!db.objectStoreNames.contains('downloads')) {
+        db.createObjectStore('downloads', { keyPath: 'trackKey' });
+      }
+      if (!db.objectStoreNames.contains('queue')) {
+        db.createObjectStore('queue', { keyPath: 'id' });
+      }
+      if (!db.objectStoreNames.contains('playback_state')) {
+        db.createObjectStore('playback_state', { keyPath: 'id' });
+      }
     };
 
-    if (action === 'save') {
-        event.waitUntil(
-            caches.open(CACHE_NAME).then((cache) => {
-                return fetch(url)
-                    .then((response) => {
-                        if (!response.ok) {
-                            throw new Error(`Network response was not ok for ${url}`);
-                        }
-                        return cache.put(url, response.clone());
-                    })
-                    .then(() => {
-                        console.log(`Cached ${url}`);
-                        respond('saved');
-                    })
-                    .catch((error) => {
-                        console.error(`Failed to cache ${url}:`, error);
-                        respond('error');
-                    });
-            })
-        );
-    } else if (action === 'remove') {
-        event.waitUntil(
-            caches.open(CACHE_NAME).then((cache) => {
-                return cache.delete(url).then((deleted) => {
-                    console.log(deleted ? `Removed ${url} from cache` : `${url} not found in cache`);
-                    respond('removed');
-                });
-            })
-        );
-    } else if (action === 'check') {
-        event.waitUntil(
-            caches.open(CACHE_NAME).then((cache) => {
-                return cache.match(url).then((response) => {
-                    respond(response ? 'saved' : 'removed');
-                });
-            })
-        );
-    }
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => reject(req.error);
+  });
+}
+
+function idbPut(db, store, value) {
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(store, 'readwrite');
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(tx.error);
+    tx.objectStore(store).put(value);
+  });
+}
+
+function idbGet(db, store, key) {
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(store, 'readonly');
+    const req = tx.objectStore(store).get(key);
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => reject(req.error);
+  });
+}
+
+function idbDelete(db, store, key) {
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(store, 'readwrite');
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(tx.error);
+    tx.objectStore(store).delete(key);
+  });
+}
+
+// Caching the application shell -------------------------------------------
+self.addEventListener('install', event => {
+  self.skipWaiting();
+  event.waitUntil(
+    caches.open(CACHE_NAME).then(cache => cache.addAll(SHELL_ASSETS))
+  );
 });
+
+self.addEventListener('activate', event => {
+  event.waitUntil(
+    caches.keys().then(names =>
+      Promise.all(names.map(name => (name === CACHE_NAME ? null : caches.delete(name))))
+    ).then(() => self.clients.claim())
+  );
+});
+
+// Helpers -----------------------------------------------------------------
+function parseRange(rangeHeader, size) {
+  // Supports only single byte range: "bytes=start-end"
+  const matches = /^bytes=([0-9]*)-([0-9]*)$/.exec(rangeHeader);
+  if (!matches) return null;
+  let start = matches[1] === '' ? 0 : Number(matches[1]);
+  let end = matches[2] === '' ? size - 1 : Number(matches[2]);
+  if (isNaN(start) || isNaN(end) || start > end || end >= size) return null;
+  return { start, end };
+}
+
+async function serveFromIDB(request) {
+  const url = new URL(request.url);
+  const trackKey = url.pathname;
+  const db = await openDB();
+  const record = await idbGet(db, 'tracks', trackKey);
+
+  if (!record || !record.blob) {
+    // Not stored offline; fall back to network
+    return fetch(request);
+  }
+
+  const blob = record.blob;
+  const mime = record.mime || 'application/octet-stream';
+
+  if (request.headers.has('range')) {
+    const range = parseRange(request.headers.get('range'), blob.size);
+    if (range) {
+      const slice = blob.slice(range.start, range.end + 1);
+      return new Response(slice, {
+        status: 206,
+        headers: {
+          'Content-Type': mime,
+          'Content-Length': String(range.end - range.start + 1),
+          'Content-Range': `bytes ${range.start}-${range.end}/${blob.size}`
+        }
+      });
+    }
+  }
+
+  return new Response(blob, {
+    headers: {
+      'Content-Type': mime,
+      'Content-Length': String(blob.size)
+    }
+  });
+}
+
+// Fetch handling -----------------------------------------------------------
+self.addEventListener('fetch', event => {
+  const url = new URL(event.request.url);
+  if (url.pathname.startsWith('/music/')) {
+    event.respondWith(serveFromIDB(event.request));
+    return;
+  }
+
+  event.respondWith(
+    caches.match(event.request).then(resp => resp || fetch(event.request))
+  );
+});
+
+// Messaging ---------------------------------------------------------------
+self.addEventListener('message', (event) => {
+  const { action, url } = event.data || {};
+  if (!action || !url) return;
+
+  if (action === 'save') {
+    event.waitUntil(saveAudioToIDBWithProgress(url, event.source));
+  } else if (action === 'remove') {
+    event.waitUntil(
+      removeAudioFromIDB(url).then(() => {
+        event.source?.postMessage({ status: 'removed', url });
+      })
+    );
+  } else if (action === 'check') {
+    event.waitUntil(
+      hasAudioInIDB(url).then((hit) => {
+        event.source?.postMessage({ status: hit ? 'saved' : 'removed', url, ...(hit || {}) });
+      })
+    );
+  }
+});
+
+async function saveAudioToIDBWithProgress(urlStr, sourceClient) {
+  const res = await fetch(urlStr);
+  if (!res.ok || !res.body) {
+    sourceClient?.postMessage({ status: 'error', url: urlStr });
+    return;
+  }
+
+  const size = Number(res.headers.get('Content-Length') || 0);
+  const mime = res.headers.get('Content-Type') || 'audio/mp4';
+  const reader = res.body.getReader();
+  const chunks = [];
+  let received = 0;
+
+  const db = await openDB();
+  const url = new URL(urlStr, self.location.origin);
+  const key = url.pathname;
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    chunks.push(value);
+    received += value.byteLength;
+    sourceClient?.postMessage({ status: 'downloading', url: urlStr, received, size });
+    await idbPut(db, 'downloads', {
+      trackKey: key,
+      state: 'downloading',
+      received,
+      size,
+      updatedAt: Date.now()
+    });
+  }
+
+  const blob = new Blob(chunks, { type: mime });
+  await saveBlobToIDB(db, key, mime, blob);
+  sourceClient?.postMessage({ status: 'saved', url: urlStr, received: blob.size, size: blob.size });
+}
+
+async function saveBlobToIDB(db, key, mime, blob) {
+  await idbPut(db, 'tracks', {
+    trackKey: key,
+    urlPath: key,
+    mime,
+    size: blob.size,
+    blob,
+    downloadedAt: Date.now()
+  });
+  await idbPut(db, 'downloads', {
+    trackKey: key,
+    state: 'downloaded',
+    received: blob.size,
+    size: blob.size,
+    updatedAt: Date.now()
+  });
+}
+
+async function removeAudioFromIDB(urlStr) {
+  const url = new URL(urlStr, self.location.origin);
+  const key = url.pathname;
+  const db = await openDB();
+  await idbDelete(db, 'tracks', key);
+  await idbDelete(db, 'downloads', key);
+}
+
+async function hasAudioInIDB(urlStr) {
+  const url = new URL(urlStr, self.location.origin);
+  const key = url.pathname;
+  const db = await openDB();
+  const rec = await idbGet(db, 'tracks', key);
+  return rec && rec.blob ? rec : null;
+}
 


### PR DESCRIPTION
## Summary
- stream audio downloads from the service worker and store progress in IndexedDB
- wait for the controlling service worker before sending page messages
- throttle download progress updates to keep the UI responsive

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b35c4309d08320b7467aa96265c601