### PR TITLE
Add offline persistence and diagnostics

### DIFF
--- a/index.html
+++ b/index.html
@@ -164,6 +164,10 @@
   <section id="debug-tools" style="width:90%;max-width:400px;margin-top:20px;background:#333;padding:10px;border-radius:5px;">
     <h2 style="margin-top:0;">Debug Tools</h2>
     <p id="online-status" style="margin:5px 0;">Status: Unknown</p>
+    <p id="db-info" style="margin:5px 0;">DB: n/a</p>
+    <p id="offline-total" style="margin:5px 0;">Offline: 0 tracks, 0 MB</p>
+    <button id="recalc-offline">Recalculate offline size</button>
+    <ul id="offline-list" style="list-style:none;padding-left:0;margin-top:10px;"></ul>
     <button id="refresh-cache">Refresh Cache List</button>
     <button id="clear-cache">Clear All Caches</button>
     <ul id="cache-list" style="list-style:none;padding-left:0;max-height:150px;overflow-y:auto;margin-top:10px;"></ul>
@@ -182,7 +186,9 @@
   </footer>
 
   <!-- JavaScript for enhanced controls -->
-  <script>
+  <script type="module">
+    import { wireAudio, resumeIfPossible } from './player-state.js';
+
     document.addEventListener('DOMContentLoaded', () => {
       if ('serviceWorker' in navigator) {
         navigator.serviceWorker.register('/sw.js')
@@ -204,7 +210,23 @@
       const trackContainers = document.querySelectorAll('.track');
       const saveButtons = document.querySelectorAll('.save-offline');
       const removeButtons = document.querySelectorAll('.remove-offline');
+      const offlineMap = new Map();
+      const offlineTotal = document.getElementById('offline-total');
+      const offlineList = document.getElementById('offline-list');
+      const recalcBtn = document.getElementById('recalc-offline');
+      const dbInfo = document.getElementById('db-info');
       let currentIndex = 0;
+      let persistenceTried = false;
+
+      const toKey = a => new URL(a.currentSrc || a.src || a.querySelector('source')?.src || '', location.href).pathname;
+      tracks.forEach(t => wireAudio(t, toKey));
+      tracks.forEach(t => resumeIfPossible(t));
+
+      const dbReq = indexedDB.open('base3');
+      dbReq.onsuccess = () => {
+        dbInfo.textContent = `DB: v${dbReq.result.version}`;
+        dbReq.result.close();
+      };
 
       const swReady = 'serviceWorker' in navigator
         ? new Promise(resolve => {
@@ -223,9 +245,35 @@
         });
       }
 
+      function showToast(msg) {
+        const div = document.createElement('div');
+        div.textContent = msg;
+        div.style.position = 'fixed';
+        div.style.bottom = '10px';
+        div.style.left = '50%';
+        div.style.transform = 'translateX(-50%)';
+        div.style.background = '#333';
+        div.style.padding = '6px 10px';
+        div.style.borderRadius = '4px';
+        document.body.appendChild(div);
+        setTimeout(() => div.remove(), 3000);
+      }
+
       saveButtons.forEach(button => {
-        button.addEventListener('click', () => {
+        button.addEventListener('click', async () => {
+          if (button.dataset.state === 'saving') {
+            sendToServiceWorker('abort', button.dataset.url);
+            return;
+          }
+          if (!persistenceTried) {
+            persistenceTried = true;
+            let granted = false;
+            try { granted = await navigator.storage?.persist?.(); } catch (e) {}
+            showToast(granted ? 'Storage will be kept when possible.' : 'Storage may be cleared by the browser.');
+          }
           sendToServiceWorker('save', button.dataset.url);
+          button.dataset.state = 'saving';
+          button.textContent = 'Cancel';
         });
       });
 
@@ -237,10 +285,34 @@
         });
       });
 
+      function updateDiagnostics() {
+        let bytes = 0;
+        offlineList.innerHTML = '';
+        saveButtons.forEach(btn => {
+          const url = btn.dataset.url;
+          const size = offlineMap.get(url) || 0;
+          if (size) bytes += size;
+          const li = document.createElement('li');
+          li.textContent = `${url} - ${size ? 'saved' : 'unsaved'}`;
+          const rmBtn = document.createElement('button');
+          rmBtn.textContent = 'Remove';
+          rmBtn.disabled = !size;
+          rmBtn.addEventListener('click', () => sendToServiceWorker('remove', url));
+          li.appendChild(rmBtn);
+          offlineList.appendChild(li);
+        });
+        offlineTotal.textContent = `Offline: ${offlineMap.size} tracks, ${(bytes / 1e6).toFixed(2)} MB`;
+      }
+
+      recalcBtn.addEventListener('click', () => {
+        saveButtons.forEach(btn => sendToServiceWorker('check', btn.dataset.url));
+      });
+
       // Check cache status on load
       saveButtons.forEach(button => {
         sendToServiceWorker('check', button.dataset.url);
       });
+      updateDiagnostics();
 
       let _lastProgressAt = 0;
       if ('serviceWorker' in navigator) {
@@ -257,29 +329,37 @@
             _lastProgressAt = now;
 
             const pct = size ? Math.round((received / size) * 100) : 0;
-            saveBtn.textContent = `Saving ${pct}%`;
-            saveBtn.disabled = true;
-            saveBtn.classList.add('disabled');
+            saveBtn.textContent = `Cancel ${pct}%`;
+            saveBtn.disabled = false;
+            saveBtn.classList.remove('disabled');
+            saveBtn.dataset.state = 'saving';
             return;
           }
 
+          saveBtn.dataset.state = '';
+
           if (status === 'saved') {
+            offlineMap.set(url, size);
             saveBtn.textContent = 'Saved';
             saveBtn.disabled = true;
             saveBtn.classList.add('disabled');
             removeBtn.disabled = false;
             removeBtn.classList.remove('disabled');
           } else if (status === 'removed') {
+            offlineMap.delete(url);
             saveBtn.textContent = 'Save for offline';
             saveBtn.disabled = false;
             saveBtn.classList.remove('disabled');
             removeBtn.disabled = true;
             removeBtn.classList.add('disabled');
           } else if (status === 'error') {
+            offlineMap.delete(url);
             saveBtn.textContent = 'Error';
             saveBtn.disabled = false;
             saveBtn.classList.remove('disabled');
           }
+
+          updateDiagnostics();
         });
       }
 

--- a/player-state.js
+++ b/player-state.js
@@ -1,0 +1,82 @@
+const DB_NAME = 'base3';
+const STORE = 'playback_state';
+
+function openDB() {
+  return new Promise((resolve, reject) => {
+    const req = indexedDB.open(DB_NAME, 1);
+    req.onupgradeneeded = () => {
+      const db = req.result;
+      if (!db.objectStoreNames.contains(STORE)) {
+        db.createObjectStore(STORE, { keyPath: 'id' });
+      }
+    };
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => reject(req.error);
+  });
+}
+
+function idbPut(db, value) {
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE, 'readwrite');
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(tx.error);
+    tx.objectStore(STORE).put(value);
+  });
+}
+
+function idbGet(db) {
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE, 'readonly');
+    const req = tx.objectStore(STORE).get('player');
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => reject(req.error);
+  });
+}
+
+export function wireAudio(audio, urlForTrackKeyFn) {
+  const dbPromise = openDB();
+  const toKey = urlForTrackKeyFn || (a => new URL(a.currentSrc || a.src, location.href).pathname);
+  audio.dataset.trackKey = toKey(audio);
+  let lastWrite = 0;
+
+  async function writeState() {
+    const db = await dbPromise;
+    const trackKey = toKey(audio);
+    await idbPut(db, {
+      id: 'player',
+      trackKey,
+      position: audio.currentTime,
+      status: audio.paused ? 'paused' : 'playing',
+      updatedAt: Date.now()
+    });
+  }
+
+  function maybeWrite() {
+    const now = Date.now();
+    if (now - lastWrite >= 2000) {
+      lastWrite = now;
+      writeState();
+    }
+  }
+
+  audio.addEventListener('timeupdate', maybeWrite);
+  audio.addEventListener('playing', maybeWrite);
+  audio.addEventListener('pause', writeState);
+  document.addEventListener('visibilitychange', () => {
+    if (document.visibilityState === 'hidden') writeState();
+  });
+}
+
+export async function resumeIfPossible(audio) {
+  const db = await openDB();
+  const rec = await idbGet(db);
+  if (!rec || (rec.status !== 'playing' && rec.status !== 'paused')) return;
+  if (audio.dataset.trackKey !== rec.trackKey) return;
+  audio.src = rec.trackKey;
+  audio.currentTime = rec.position || 0;
+  if (rec.status === 'playing') {
+    try { await audio.play(); } catch (e) {}
+  } else {
+    audio.pause();
+  }
+}

--- a/sw.js
+++ b/sw.js
@@ -10,6 +10,7 @@ const SHELL_ASSETS = [
 // IndexedDB setup ----------------------------------------------------------
 const DB_NAME = 'base3';
 const DB_VERSION = 1;
+const inFlight = new Map(); // url -> {controller, lastPostTs}
 
 function openDB() {
   return new Promise((resolve, reject) => {
@@ -182,12 +183,28 @@ self.addEventListener('message', (event) => {
         event.source?.postMessage({ status: hit ? 'saved' : 'removed', url, ...(hit || {}) });
       })
     );
+  } else if (action === 'abort') {
+    const rec = inFlight.get(url);
+    if (rec) rec.controller.abort('user-abort');
+    event.source?.postMessage({ status: 'removed', url });
   }
 });
 
 async function saveAudioToIDBWithProgress(urlStr, sourceClient) {
-  const res = await fetch(urlStr);
+  const controller = new AbortController();
+  inFlight.set(urlStr, { controller, lastPostTs: 0 });
+  let res;
+  try {
+    res = await fetch(urlStr, { signal: controller.signal });
+  } catch (err) {
+    inFlight.delete(urlStr);
+    if (err.name === 'AbortError') return;
+    sourceClient?.postMessage({ status: 'error', url: urlStr });
+    return;
+  }
+
   if (!res.ok || !res.body) {
+    inFlight.delete(urlStr);
     sourceClient?.postMessage({ status: 'error', url: urlStr });
     return;
   }
@@ -202,23 +219,39 @@ async function saveAudioToIDBWithProgress(urlStr, sourceClient) {
   const url = new URL(urlStr, self.location.origin);
   const key = url.pathname;
 
-  while (true) {
-    const { done, value } = await reader.read();
-    if (done) break;
-    chunks.push(value);
-    received += value.byteLength;
-    sourceClient?.postMessage({ status: 'downloading', url: urlStr, received, size });
-    await idbPut(db, 'downloads', {
-      trackKey: key,
-      state: 'downloading',
-      received,
-      size,
-      updatedAt: Date.now()
-    });
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      chunks.push(value);
+      received += value.byteLength;
+      const rec = inFlight.get(urlStr);
+      const now = performance.now();
+      if (rec && now - rec.lastPostTs >= 120) {
+        sourceClient?.postMessage({ status: 'downloading', url: urlStr, received, size });
+        rec.lastPostTs = now;
+      }
+      await idbPut(db, 'downloads', {
+        trackKey: key,
+        state: 'downloading',
+        received,
+        size,
+        updatedAt: Date.now()
+      });
+    }
+  } catch (err) {
+    inFlight.delete(urlStr);
+    if (err.name === 'AbortError') {
+      await idbDelete(db, 'downloads', key);
+      return;
+    }
+    sourceClient?.postMessage({ status: 'error', url: urlStr });
+    return;
   }
 
   const blob = new Blob(chunks, { type: mime });
   await saveBlobToIDB(db, key, mime, blob);
+  inFlight.delete(urlStr);
   sourceClient?.postMessage({ status: 'saved', url: urlStr, received: blob.size, size: blob.size });
 }
 


### PR DESCRIPTION
## Summary
- prompt for persistent storage on first save and expose cancelable download progress
- track offline bytes and DB info in new debug diagnostics panel
- persist and resume playback position via new player-state module and AbortController-based SW logic

## Testing
- `node --check player-state.js`
- `node --check sw.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b364beef348320a75a1cb033779f30