### PR TITLE
Guard navigator access in service worker

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -289,8 +289,9 @@ async function saveAudioToIDBWithProgress(urlStr, sourceClient) {
     if (err.name === 'QuotaExceededError') {
       let info;
       try {
-        if (navigator.storage && navigator.storage.estimate) {
-          const est = await navigator.storage.estimate();
+        const nav = self.navigator;
+        if (nav && nav.storage && nav.storage.estimate) {
+          const est = await nav.storage.estimate();
           info = { usage: est.usage, quota: est.quota };
         }
       } catch (e) {


### PR DESCRIPTION
## Summary
- Guard `navigator.storage` lookup in service worker against undefined `navigator`
- Prevent quota errors from causing unhandled ReferenceError, returning proper status to client

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bdacf9a2f883208a8e625dcdaebd09