### PR TITLE
Improve service worker navigation fallback and add offline regression checklist

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,21 @@ online status and lists everything stored in the service worker cache. You can
 refresh the list or clear all caches directly from the page to help troubleshoot
 offline behaviour.
 
+## Offline regression checklist
+Use this quick smoke test after service worker or playback changes:
+
+1. Open the site while online and wait for the service worker to activate.
+2. Save at least one track with **Save for offline**.
+3. Disable network (DevTools → Offline) and refresh.
+4. Confirm the app shell still loads from cache.
+5. Play the saved track and seek within it.
+6. Reload once more while still offline and verify playback state resumes.
+
+The service worker also includes a navigation fallback that first tries a cached
+navigation match with query strings ignored, then falls back to `/index.html` (or
+`/`). This keeps direct offline reloads working even when the requested URL shape
+does not exactly match a cached key.
+
 ## License
 This project is made available under **your choice** of the following licenses:
 

--- a/sw.js
+++ b/sw.js
@@ -202,12 +202,30 @@ self.addEventListener('fetch', event => {
     const cached = await caches.match(req);
     if (cached) return cached;
 
-    const response = await fetch(req);
-    if (req.method === 'GET' && response.ok && url.origin === self.location.origin) {
-      const cache = await caches.open(CACHE_NAME);
-      cache.put(req, response.clone());
+    // Navigations often include query params that should still map to shell.
+    if (req.mode === 'navigate') {
+      const cachedNav = await caches.match(req, { ignoreSearch: true });
+      if (cachedNav) return cachedNav;
     }
-    return response;
+
+    try {
+      const response = await fetch(req);
+      if (req.method === 'GET' && response.ok && url.origin === self.location.origin) {
+        const cache = await caches.open(CACHE_NAME);
+        cache.put(req, response.clone());
+      }
+      return response;
+    } catch (error) {
+      // Keep SPA navigation resilient when users launch while offline.
+      if (req.mode === 'navigate') {
+        const fallback =
+          (await caches.match(req, { ignoreSearch: true })) ||
+          (await caches.match('/index.html')) ||
+          (await caches.match('/'));
+        if (fallback) return fallback;
+      }
+      throw error;
+    }
   })());
 });
 


### PR DESCRIPTION
### Motivation

- Make SPA navigation more resilient when launched or reloaded offline by matching cached navigation entries while ignoring query strings and providing a fallback to the app shell.
- Provide a concise smoke-test checklist so regressions in service worker or playback behavior can be quickly validated.

### Description

- Update `sw.js` fetch handler to first check `caches.match(req, { ignoreSearch: true })` for navigations and return a cached navigation if present.
- Wrap the network fetch in a `try/catch` and, on failure for `req.mode === 'navigate'`, attempt to return a cached navigation or fall back to `/index.html` or `/` before rethrowing the error.
- Keep existing caching behavior for successful GET responses and audio-serving logic via `serveFromIDBOrNetwork`, and add explanation to `README.md` describing the navigation fallback behavior.
- Add an "Offline regression checklist" section to `README.md` with step-by-step smoke test instructions for service worker and playback changes.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c9478f66a083209446b0d75cc6c915)